### PR TITLE
Manual: Help debug issues when using as a NixOS module

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -166,6 +166,15 @@ home-manager.users.eve = { pkgs, ... }: {
 and after a `nixos-rebuild switch` the user eve's environment should
 include a basic Bash configuration and the packages atool and httpie.
 
+[NOTE]
+====
+If after a `nixos-rebuild switch` you *don't* have the environment
+you expect, you can take a look at home-manager's output with
+
+[source,bash]
+systemctl status "home-manager-$user.service"
+====
+
 If you do not plan on having Home Manager manage your shell
 configuration then you must add either
 


### PR DESCRIPTION
Yes, something did go wrong, and no, I had no clue what it was nor how to have more info.

Thankfully I fell upon [this issue](https://github.com/nix-community/home-manager/issues/2464)
which gave me the key to getting HM's output.

The issue was trivial to fix (a config file was in HM's way), but I had to have the info.

### Description

Add note in the 1.2 NixOS Module section of the manual to help solve issues when using home-manager as a nixos module.

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
